### PR TITLE
Replace std rwlock with parking lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "futures 0.3.24",
  "futures-util",
  "log",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,6 +11,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 uuid = { version = "1.2.1", features = ["v4"] }
 futures-util = { version = "0.3.24", features = ["sink", "channel", "futures_01"] }
+parking_lot = "0.12.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
note that this is pointing at the secure-web-sockets branch.

replaces the std lib RwLock with the RwLock implementation from the parking_lot library.
Because panics by the write-lock holder no longer poisons the RwLock, it doesn't return a Result, so we can get rid of the expect() calls.